### PR TITLE
AddInitializeBCALXliffCommentsInAL

### DIFF
--- a/BCALDevHelper.psd1
+++ b/BCALDevHelper.psd1
@@ -76,8 +76,9 @@
 
             'Get-BCALXliffAsArray',
             'Sync-BCALTransunitTargetsToXliffSyncComment'
+            ,'Initialize-BCALXliffCommentsInAL'
 
-            'Update-BCALAppJson'
+            ,'Update-BCALAppJson'
         )
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/BCALDevHelper.psm1
+++ b/BCALDevHelper.psm1
@@ -22,5 +22,6 @@ Write-Host ">Hello $($myUsername)!" -ForegroundColor DarkCyan
 
 . (Join-Path $PSScriptRoot ".\XLIFF\Get-BCALXliffAsArray\Get-BCALXliffAsArray.ps1")
 . (Join-Path $PSScriptRoot ".\XLIFF\Sync-BCALTransunitTargetsToXliffSyncComment\Sync-BCALTransunitTargetsToXliffSyncComment.ps1")
+. (Join-Path $PSScriptRoot ".\XLIFF\Initialize-BCALXliffCommentsInAL/Initialize-BCALXliffCommentsInAL.ps1")
 
 . (Join-Path $PSScriptRoot ".\Update-BCALAppJson\Update-BCALAppJson.ps1")

--- a/XLIFF/Initialize-BCALXliffCommentsInAL/Initialize-BCALXliffCommentsInAL.ps1
+++ b/XLIFF/Initialize-BCALXliffCommentsInAL/Initialize-BCALXliffCommentsInAL.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+Processes AL files to insert XLIFF comments for specific properties and labels and could updates default English action tooltips to a specified language.
+.DESCRIPTION
+This function scans AL files within a specified directory, identifies translatable properties and labels, and adds XLIFF comments based on a given language code. It also could updates default English field tooltips ("Specifies the value of the (.*?) field.") to a specified language tooltip. The function logs detailed information about its processing steps.
+.PARAMETER SourceFilePath
+Specifies the root path where the AL files are located. This parameter is mandatory.
+.PARAMETER LogFilePath
+Specifies the file path for logging verbose messages of this module.
+.PARAMETER LanguageCode
+The language code to use in the XLIFF comments. Default is 'de-DE'.
+.PARAMETER ReplaceDefaultENUFieldToolTipWith
+Text to replace the default English field tooltips ("Specifies the value of the (.*?) field.") with the specified language tooltip. Default is the German 'Gibt den Wert des Feldes "$3" an.'.
+
+.EXAMPLE
+# This example processes AL files in the `C:\Projects\ALFiles` directory, logs messages to `C:\Logs\BCALLog.txt`, uses French for XLIFF comments, and replaces the default English tooltip with a French version.
+Initialize-BCALXliffCommentsInAL -SourceFilePath "C:\Projects\ALFiles" -LogFilePath "C:\Logs\BCALLog.txt" -LanguageCode "fr-FR" -ReplaceDefaultENUFieldToolTipWith "Spécifie la valeur du champ « $3 »."
+
+.EXAMPLE
+# This example processes AL files in the `C:\ALFiles` directory, uses the default German language code 'de-DE', and not replace the default English field tooltips.
+Initialize-BCALXliffCommentsInAL -SourceFilePath "C:\ALFiles"
+
+.NOTES
+Ensure the AL files are accessible and not locked by other processes during execution. Also that everything is commited before you execute this function.
+If processing large directories, consider the performance impact.
+#>
+# TODO: Report Labels?
+function Initialize-BCALXliffCommentsInAL {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceFilePath,
+
+        [string]$LogFilePath,
+        [string]$LanguageCode = 'de-DE',
+        [string]$ReplaceDefaultENUFieldToolTipWith = 'Gibt den Wert des Feldes "$3" an.'
+    )
+
+    begin {}
+
+    process {
+        Write-BCALLog -Level VERBOSE "SourceFilePath $($SourceFilePath)" -logfile $LogFilePath
+
+        $filter = "*.al"
+        Write-BCALLog -Level VERBOSE "Filter files with '$($filter)'" -logfile $LogFilePath
+
+        $ALFiles = Get-ChildItem $SourceFilePath -Filter $filter -Recurse 
+        $ALFiles | ForEach-Object {
+            $CurrFile = $_;
+            Write-BCALLog -Level VERBOSE "$($CurrFile.Fullname)" -logfile $LogFilePath
+            Write-BCALLog -Level VERBOSE "Path is available:$($(Test-Path $CurrFile.Fullname))" -logfile $LogFilePath
+
+            $file = Get-Item $SourceFilePath -Force -ea SilentlyContinue
+            $isSymLink = [bool]($file.Attributes -band [IO.FileAttributes]::ReparsePoint)
+            Write-BCALLog -Level VERBOSE "Path is Symlink:$($isSymLink)" -logfile $LogFilePath
+
+            if ((Test-Path $_.Fullname) -and (!$isSymLink)) {
+                # Get Content
+                [string]$FileContent = Get-Content -Path $CurrFile.FullName -Raw
+                if (![string]::IsNullOrEmpty($FileContent)) {
+                    Write-BCALLog -Level VERBOSE "Object found: '$($CurrFile.FullName)'" -logfile $LogFilePath
+                }
+
+                # Perform the regex replacement
+                $newContent = $FileContent
+                
+                #region Add XLIFF Sync Language Comment
+                [string]$TranslatablePropertiesRegEx = "((Caption|ToolTip|InstructionalText)\s*=\s*'([^']+?)');"
+                [string]$ReplacementForProperties = "`$1, Comment = '$($LanguageCode)=`$3';"
+                $newContent = [regex]::Replace($newContent, $TranslatablePropertiesRegEx, $ReplacementForProperties)
+                
+                [string]$TranslatableLabelRegEx = "((Label)\s*'([^']+?)');"
+                [string]$ReplacementForLabel = "`$1, Comment = '$($LanguageCode)=`$3';"
+                $newContent = [regex]::Replace($newContent, $TranslatableLabelRegEx, $ReplacementForLabel)                
+                #endregion
+                
+                #region Replace ENU Default to language Default for Action
+                # if 
+                if (![string]::IsNullOrEmpty($ReplaceDefaultENUFieldToolTipWith)) {
+                    [string]$ChangeDefaultENUTranslationToDefaultLanguageCommentRegEx = "($($LanguageCode)=)(Specifies the value of the (.*?) field.)"
+                    [string]$ReplacementForDefaultLanguageComment = "`$1$($ReplaceDefaultENUFieldToolTipWith)"
+                    $newContent = [regex]::Replace($newContent, $ChangeDefaultENUTranslationToDefaultLanguageCommentRegEx, $ReplacementForDefaultLanguageComment)
+                }
+                #endregion
+
+                # Write the modified content back to the file
+                # Set-Content -Path $CurrFile.FullName -Value $newContent
+                $newContent | Out-File -FilePath $CurrFile.FullName -NoNewline -Force 
+            }
+        }
+
+    }
+
+    end {}    
+}
+Export-ModuleMember -Function Initialize-BCALXliffCommentsInAL

--- a/XLIFF/Sync-BCALTransunitTargetsToXliffSyncComment/Sync-BCALTransunitTargetsToXliffSyncComment.ps1
+++ b/XLIFF/Sync-BCALTransunitTargetsToXliffSyncComment/Sync-BCALTransunitTargetsToXliffSyncComment.ps1
@@ -64,7 +64,7 @@ function Sync-BCALTransunitTargetsToXliffSyncComment {
         else {
             $fileCount = 1;
         }        
-        Write-BCALLog "AL Fiels: $($fileCount)" -Level VERBOSE
+        Write-BCALLog "AL Fields: $($fileCount)" -Level VERBOSE
         
         $currFile = 0;
         $changedPropertyComment = 0;

--- a/docs/Initialize-BCALXliffCommentsInAL/ReadMe.md
+++ b/docs/Initialize-BCALXliffCommentsInAL/ReadMe.md
@@ -1,0 +1,24 @@
+# Initialize-BCALXliffCommentsInAL
+
+This function will prepare the AL Files for the [XLIFF Sync](https://marketplace.visualstudio.com/items?itemName=rvanbekkum.xliff-sync) VS Code Extension (and PowerShell module). It will add the Comment for a given language code and could also replace the default english field tooltip.
+It will not translating anything else. It only adds the comment with the default value of the properties. With the language code you should set your wished language. Sorry to set it to german by default :)
+
+> ⚠️ Please commit everything before you start this.
+
+## Reconized Variables/Properties
+
+- Caption
+- ToolTip
+- InstructionalText
+- Label Variables
+
+## Features
+- Adds XLIFF comments to translatable properties and labels.
+- Optionally replaces default English field tooltips with a specified language version.
+- Logs detailed processing information to a specified log file.
+
+
+## Notes
+- Ensure the AL files are accessible and not locked by other processes during execution.
+- Make sure all changes are committed before running this function to avoid conflicts.
+- Consider the performance impact if processing large directories.

--- a/docs/Update-BCALAppJson/ReadMe.md
+++ b/docs/Update-BCALAppJson/ReadMe.md
@@ -1,0 +1,3 @@
+# Update-BCALAppJson
+
+TODO: Add Docs...


### PR DESCRIPTION
This function will prepare the AL Files for the [XLIFF Sync](https://marketplace.visualstudio.com/items?itemName=rvanbekkum.xliff-sync) VS Code Extension (and PowerShell module). It will add the Comment for a given language code and could also replace the default english field tooltip.
It will not translating anything else. It only adds the comment with the default value of the properties. With the language code you should set your wished language. Sorry to set it to german by default :)