### PR TITLE
🛠️Change: BCALObject Metadata only at Start

### DIFF
--- a/src/Get-BCALObjects/Get-BCALObjects.ps1
+++ b/src/Get-BCALObjects/Get-BCALObjects.ps1
@@ -66,7 +66,7 @@ function Get-BCALObjects {
 
                 # Get Object ObjectType, ID, Name 
                 # $regex = '^(\w+)\s(\d*)\s"(.*)"'
-                $regex = '(?<Type>\w+)\s(?<ID>\d*)\s"(?<Name>.*?)"(?:\s(extends)\s"(.*)")?'
+                $regex = '^(?<Type>\w+)\s(?<ID>\d*)\s"(?<Name>.*?)"(?:\s(extends)\s"(.*)")?'
 
                 $FileContentObject = select-string -InputObject $FileContent -Pattern $regex -AllMatches | ForEach-Object { $_.Matches }
                 


### PR DESCRIPTION
Because some object might have comments with the same metadata structre then the line that here is meant.